### PR TITLE
Make methods fluent and also add more methods to class

### DIFF
--- a/src/InitRed/Tabula/Tabula.php
+++ b/src/InitRed/Tabula/Tabula.php
@@ -25,8 +25,21 @@ class Tabula
     public $os;
     public $encoding = 'utf-8';
     public $javaOptions = [];
-    public $options = [];
     public $input = null;
+    public $options = [
+        'pages' => null,
+        'guess' => true,
+        'area' => [],
+        'relativeArea' => false,
+        'lattice' => false,
+        'stream' => false,
+        'password' => null,
+        'silent' => false,
+        'columns' => null,
+        'format' => null,
+        'batch' => null,
+        'outfile' => null,
+    ];
 
     /**
      * Additional dir to check for java executable
@@ -42,6 +55,7 @@ class Tabula
     /**
      * Tabula constructor.
      * @param null $binDir
+     * @param string $encoding
      */
     public function __construct($binDir = null, $encoding = 'utf-8')
     {
@@ -94,10 +108,13 @@ class Tabula
 
     /**
      * @param string $jarArchive
+     * @return Tabula
      */
-    public function setJarArchive($jarArchive)
+    public function setJarArchive(string $jarArchive)
     {
         $this->jarArchive = $jarArchive;
+
+        return $this;
     }
 
     /**
@@ -110,11 +127,37 @@ class Tabula
 
     /**
      * @param $binDir
+     * @return Tabula
      */
     public function setBinDir($binDir)
     {
         $this->binDir = $binDir;
+
+        return $this;
     }
+
+    /**
+     * @param string $input
+     * @return Tabula
+     */
+    public function setPdf(string $input)
+    {
+        $this->input = $input;
+
+        return  $this;
+    }
+
+    /**
+     * @param array $options
+     * @return Tabula
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = array_merge($this->options, $options);
+
+        return $this;
+    }
+
 
     public function buildJavaOptions()
     {
@@ -143,6 +186,10 @@ class Tabula
         $this->javaOptions = $javaOptions;
     }
 
+    /**
+     * @param $format
+     * @return string
+     */
     public function extractFormatForConversion($format)
     {
         if(empty($format)) {
@@ -158,136 +205,115 @@ class Tabula
         }
     }
 
+    /**
+     * @param $path
+     * @return bool
+     */
     public function existFileCheck($path)
     {
         if(!file_exists($path)) {
             throw new InvalidArgumentException('File does not exist.');
         }
 
+        if (!is_readable($path)) {
+            throw new InvalidArgumentException("Could not read `{$path}`");
+        }
+
         return true;
     }
 
+    /**
+     * @param $path
+     * @return bool
+     */
     public function existDirectoryCheck($path)
     {
         if(!is_dir($path)) {
             throw new InvalidArgumentException('Folder to target Pdf does not exist.');
         }
+
+        return true;
     }
 
-    public function addInputOption($input)
-    {
-        $this->input = $input;
-    }
 
     /**
-     * @param null $pages
-     * @param bool $guess
-     * @param null $area
-     * @param bool $relativeArea
-     * @param bool $lattice
-     * @param bool $stream
-     * @param null $password
-     * @param bool $silent
-     * @param null $columns
-     * @param null $format
-     * @param null $batch
-     * @param null $outputPath
-     * @param string $options
+     * @param array $options
      */
-    public function buildOptions(
-        $pages = null,
-        $guess = true,
-        $area = null,
-        $relativeArea = false,
-        $lattice = false,
-        $stream = false,
-        $password = null,
-        $silent = false,
-        $columns = null,
-        $format = null,
-        $batch = null,
-        $outputPath = null,
-        $options = ''
-    ) {
-        $this->options = [];
-
+    public function buildOptions(array $options)
+    {
         $buildOptions = [];
 
-        if(!is_null($this->input)) {
-            if($this->existFileCheck($this->input)) {
+        if (! is_null($this->input)) {
+            if ($this->existFileCheck($this->input)) {
                 $buildOptions = array_merge($buildOptions, [$this->input]);
             }
         }
 
-        if(!is_null($pages)) {
-            if($pages === 'all') {
+        if (! is_null($options['pages'])) {
+            if ($options['pages'] === 'all') {
                 $buildOptions = array_merge($buildOptions, ['--page', 'all']);
             } else {
-                $area = implode( ',', $pages);
-                $buildOptions = array_merge($buildOptions, ['--page', $pages]);
+                $options['area'] = implode(',', [$options['pages']]);
+                $buildOptions = array_merge($buildOptions, ['--page', $options['pages']]);
             }
         }
 
         $multipleArea = false;
 
-        if(!is_null($area)) {
-            $guess = false;
+        if (! is_null($options['area']) && !empty($options['area'])) {
+            $options['guess'] = false;
 
-            foreach($area as $key => $value) {
-                if(substr( $value, 0, 1 ) === '%') {
-                    if($relativeArea) {
-                        $area[$key] = str_replace('%', '', $area[$key]);
+            foreach ($options['area'] as $key => $value) {
+                if (substr($value, 0, 1) === '%') {
+                    if ($options['relativeArea']) {
+                        $options['area'][$key] = str_replace('%', '', $options['area'][$key]);
                     }
                 }
             }
 
-            $area = implode( ',', $area);
+            $options['area'] = implode(',', $options['area']);
 
-            $buildOptions = array_merge($buildOptions, ["--area", $area]);
+            $buildOptions = array_merge($buildOptions, ['--area', $options['area']]);
         }
 
-        if($lattice) {
-            $buildOptions = array_merge($buildOptions, ["--lattice"]);
+        if ($options['lattice']) {
+            $buildOptions = array_merge($buildOptions, ['--lattice']);
         }
 
-        if($stream) {
-            $buildOptions = array_merge($buildOptions, ["--stream"]);
+        if ($options['stream']) {
+            $buildOptions = array_merge($buildOptions, ['--stream']);
         }
 
-        if($guess && !$multipleArea) {
-            $buildOptions = array_merge($buildOptions, ["--guess"]);
+        if ($options['guess'] && ! $multipleArea) {
+            $buildOptions = array_merge($buildOptions, ['--guess']);
         }
 
-        if(!is_null($format)) {
-
-            $format = $this->extractFormatForConversion($format);
-            $buildOptions = array_merge($buildOptions, ["--format", $format]);
+        if (! is_null($options['format'])) {
+            $format = $this->extractFormatForConversion($options['format']);
+            $buildOptions = array_merge($buildOptions, ['--format', $format]);
         }
 
-        if(!is_null($outputPath)) {
-            $buildOptions = array_merge($buildOptions, ["--outfile", $outputPath]);
+        if (! is_null($options['outfile'])) {
+            $buildOptions = array_merge($buildOptions, ['--outfile', $options['outfile']]);
         }
 
-        if(!is_null($columns)) {
-            $columns = implode( ',', $columns );
-            $buildOptions = array_merge($buildOptions, ["--columns", $columns]);
+        if (! is_null($options['columns'])) {
+            $columns = implode(',', $options['columns']);
+            $buildOptions = array_merge($buildOptions, ['--columns', $columns]);
         }
 
-        if(!is_null($password)) {
-            $buildOptions = array_merge($buildOptions, ["--password", $password]);
+        if (! is_null($options['password'])) {
+            $buildOptions = array_merge($buildOptions, ['--password', $options['password']]);
         }
 
-        if(!is_null($batch)) {
-
-            if(!is_dir($batch)) {
-                throw new InvalidArgumentException('Folder to output Pdf does not exist.');
+        if (! is_null($options['batch'])) {
+            if ($this->existDirectoryCheck($options['batch'])) {
+                $buildOptions = array_merge($buildOptions, ['--batch', $options['batch']]);
             }
-
-            $buildOptions = array_merge($buildOptions, ['--batch', $batch]);
         }
 
-        if($silent) {
-            $buildOptions = array_merge($buildOptions, ["--silent"]);
+        if ($options['silent']) {
+            $buildOptions = array_merge($buildOptions, ['--silent']);
         }
 
         $this->options = $buildOptions;
@@ -298,6 +324,7 @@ class Tabula
         $parameters = array_merge($this->javaOptions, $this->options);
 
         $process = new Process($parameters);
+
         $process->run();
 
         if (!$process->isSuccessful()) {
@@ -307,57 +334,10 @@ class Tabula
         $process->getOutput();
     }
 
-    /**
-     * @param $input
-     * @param $output
-     * @param string $format
-     * @param string $pages
-     */
-    public function convertInto($input, $output, $format = 'csv', $pages = 'all')
+    public function convert()
     {
         self::buildJavaOptions();
-        self::addInputOption($input);
-        self::buildOptions(
-            $pages,
-            true,
-            null,
-            false,
-            false,
-            false,
-            null,
-            false,
-            null,
-            $format,
-            null,
-            $output,
-            null
-        );
-        self::run();
-    }
-
-    /**
-     * @param $directory
-     * @param string $format
-     * @param string $pages
-     */
-    public function convertIntoByBatch($directory, $format = 'csv', $pages = 'all')
-    {
-        self::buildJavaOptions();
-        self::buildOptions(
-            $pages,
-            true,
-            null,
-            false,
-            false,
-            false,
-            null,
-            false,
-            null,
-            $format,
-            $directory,
-            null,
-            null
-        );
+        self::buildOptions($this->options);
         self::run();
     }
 }

--- a/src/InitRed/Tabula/Tabula.php
+++ b/src/InitRed/Tabula/Tabula.php
@@ -159,7 +159,7 @@ class Tabula
     }
 
 
-    public function buildJavaOptions()
+    private function buildJavaOptions()
     {
         $javaOptions = ['java'];
 
@@ -239,7 +239,7 @@ class Tabula
     /**
      * @param array $options
      */
-    public function buildOptions(array $options)
+    private function buildOptions(array $options)
     {
         $buildOptions = [];
 
@@ -319,7 +319,7 @@ class Tabula
         $this->options = $buildOptions;
     }
 
-    public function run()
+    private function run()
     {
         $parameters = array_merge($this->javaOptions, $this->options);
 


### PR DESCRIPTION
I added some methods to the Tabula Class and also made some of the methods fluent.

- `setPdf(string $input)`: This method accepts the PDF file which needs to be converted. It returns the `Tabula` class

- `setOptions(array $options)`: This method accepts an array of options. These options are the options required by `tabula`. 
Options by default are:
```
[
        'pages' => null,
        'guess' => true,
        'area' => [],
        'relativeArea' => false,
        'lattice' => false,
        'stream' => false,
        'password' => null,
        'silent' => false,
        'columns' => null,
        'format' => null,
        'batch' => null,
        'outfile' => null,
]
```

- `buildOptions(array $options)`: This now accepts are the options required by tabula in an array form. Now the method is `private`

- `buildJavaOptions()`: This method is currently `private`.

- `run()`: This method is currently `private`.

- `convert()`: This is the final method that has to be called to handle the conversion of the PDF file